### PR TITLE
Arreglar Add1

### DIFF
--- a/bools/compiler.ml
+++ b/bools/compiler.ml
@@ -189,7 +189,7 @@ let rec compile_expr (e : expr) (env : env) : instruction list =
     compile_expr e1 env @
     [ ITest (Reg RAX, Const 1L) ;
       IJnz "error_not_number" ;
-      IAdd (Reg RAX, Const 1L) ]
+      IAdd (Reg RAX, Const 2L) ]
   | ECall (f, args) ->
     (* acomodar los argumentos *)
     if List.length args > 6 then


### PR DESCRIPTION
Compilador solo reconoce numeros pares como numeros. Se le suma 2 en vez de uno en Add 1.