### PR TITLE
Fix #7 + Fix #8

### DIFF
--- a/bools/compiler.ml
+++ b/bools/compiler.ml
@@ -66,7 +66,6 @@ let reg_to_string r =
   | RDI -> "rdi"
   | R11 -> "r11"
   | RDX -> "RDX"
-  | RDI -> "RDI"
   | RSI -> "RSI"
   | RCX -> "RCX"
   | R8 -> "R8"
@@ -164,6 +163,8 @@ and anf e =
     ELet (temp, anf e1, EIfnz (EId temp, anf e2, anf e3))
   | ECall (f, args) ->
     callhelper(f, args, [])
+;;
+
 let min_cobra_int = Int64.div Int64.min_int 2L
 let max_cobra_int = Int64.div Int64.max_int 2L
 
@@ -311,6 +312,6 @@ let () =
   let infile = (open_in (Sys.argv.(1))) in
   let lexbuf = Lexing.from_channel infile in
   let input_ast =  Parser.expr Lexer.token lexbuf in
-  let _ = anf input_ast in
-  let program = (compile_prog input_ast) in
+  let anfed = anf input_ast in
+  let program = (compile_prog anfed) in
   printf "%s\n" program;;

--- a/bools/lexer.mll
+++ b/bools/lexer.mll
@@ -13,6 +13,7 @@ rule token = parse
   | "if"              { IF }
   | "true"            { TRUE }
   | "false"           { FALSE }
+  | "print"           { PRINT }
   | '+'               { PLUS }
   | '-'               { MINUS }
   | '*'               { TIMES }

--- a/bools/parser.mly
+++ b/bools/parser.mly
@@ -10,6 +10,7 @@
 %token LET
 %token IF
 %token TRUE FALSE
+%token PRINT
 
 %start <Syntax.expr> expr
 %{ open Syntax %}
@@ -28,7 +29,8 @@ expr:
   { EId id }
 | LPAREN LET LPAREN s = ID e1 = expr RPAREN e2 = expr RPAREN
   { ELet (s, e1, e2) }
-
+| LPAREN PRINT e = expr RPAREN
+  { EPrim1 (Print, e) }
 /* estos no los he arreglado
  LPAREN IFNZ e1 = expr e2 = expr e3 = expr RPAREN
     { Ifnz (e1, e2, e3) }

--- a/bools/syntax.ml
+++ b/bools/syntax.ml
@@ -4,6 +4,7 @@ type prim1 =
   | Not
   | Add1
   | Sub1
+  | Print
 
 type prim2 =
   | Plus


### PR DESCRIPTION
Implements `Print` as a funcion of type `EPrim1` and fixes some tabulation mistakes in the generated assembly code (for now).